### PR TITLE
RedisSocketReplicator支持自定义heartbeat Executor

### DIFF
--- a/src/main/java/com/moilioncircle/redis/replicator/Configuration.java
+++ b/src/main/java/com/moilioncircle/redis/replicator/Configuration.java
@@ -17,6 +17,7 @@
 package com.moilioncircle.redis.replicator;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.net.ssl.HostnameVerifier;
@@ -168,7 +169,12 @@ public class Configuration {
      * psync offset
      */
     private final AtomicLong replOffset = new AtomicLong(-1);
-
+    
+    /**
+     * heartbeat executor
+     */
+    private ScheduledExecutorService executor;
+    
     public int getConnectionTimeout() {
         return connectionTimeout;
     }
@@ -378,6 +384,15 @@ public class Configuration {
 
     public Configuration setHostnameVerifier(HostnameVerifier hostnameVerifier) {
         this.hostnameVerifier = hostnameVerifier;
+        return this;
+    }
+    
+    public ScheduledExecutorService getExecutor() {
+        return executor;
+    }
+    
+    public Configuration setExecutor(ScheduledExecutorService executor) {
+        this.executor = executor;
         return this;
     }
     


### PR DESCRIPTION
目前，每个`RedisSocketReplicator`对象在调用`open()`方法时，都会创建一个`newSingleThreadScheduledExecutor`，如果可以支持用户自定义线程池的话，是可以节省一些资源的。